### PR TITLE
for Return type bool return false only if all operands are 0 

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -448,7 +448,9 @@ impl Return for [u8; 4] {
 }
 
 impl Return for bool {
-    fn from_operand(array: [u8; 4]) -> bool {(array[0] & 1) != 0}
+    fn from_operand(array: [u8; 4]) -> bool {
+        array[0] != 0 || array[1] != 0 || array[2] != 0 || array[3] != 0
+    }
 }
 
 impl Return for i32 {


### PR DESCRIPTION
Checking only the last bit can result in the wrong behaviour. For example, using the Instruction RFS with Type: Status, the documentation for TMCM-1140 states: 
 - 0: no ref. reach active
 - other values: reference search active

The original implementation returned false in some cases where the motor was still initializing and the Status returned a non-zero value (12). This PR fixes this issue and allows for correct initialization.